### PR TITLE
add -y to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER DAEUN28
 COPY . /Mongli-Server
 
 RUN apt-get update
-RUN apt-get install libcurl4-openssl-dev libssl-dev 
+RUN apt-get install -y libcurl4-openssl-dev libssl-dev 
 RUN apt-get install -y libmysqlclient-dev
 
 WORKDIR /Mongli-Server


### PR DESCRIPTION
add -y in 
 `RUN apt-get install libcurl4-openssl-dev libssl-dev`
like
 `RUN apt-get install -y libcurl4-openssl-dev libssl-dev` 

for solving this:
`
Do you want to continue? [Y/n] Abort.
The command '/bin/sh -c apt-get install libcurl4-openssl-dev libssl-dev' returned a non-zero code: 1
`
